### PR TITLE
Move file function

### DIFF
--- a/README.org
+++ b/README.org
@@ -216,6 +216,13 @@ Use ~obsidian-tag-find~ to list all notes that contain a tag. Let's you choose a
   M-x obsidian-tag-find RET
 #+end_src
 
+** Move note to another folder
+Use ~obsidian-move-file~ to move current note to another folder:
+
+#+begin_src
+  M-x obsidian-move-file RET
+#+end_src
+
 *** Development tasks
 - [X] Specify Obsidian folder and save it in variables
 - [X] Enumerate files in the Obsidian folder and save a list


### PR DESCRIPTION
hi @licht1stein, 
thanks for the lib. 

A lot of time in obsidian I create a note in my inbox folder and then when I feel like it's completed I move it somewhere else with Obsidian's `Move current file to another folder` command. 
That's something I miss a lot in this lib so I added that function for myself. 

If you think it may be useful for you and others - feel free to merge then (let me know if I missed anything though, I'll update).