### PR TITLE
fixed obsidian-backlink-jump functionality

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,6 +23,7 @@ Emacs front-end for [[https://obsidian.md/][Obsidian Notes]].
 - [[#why-obsidianel-and-not][Why obsidian.el and not...]]
   - [[#obsidian-app-itself-athens-research-or-any-other-great-app][Obsidian App itself, Athens Research or any other great app?]]
   - [[#org-roam-or-any-other-great-emacs-libraries][Org-roam or any other great Emacs libraries?]]
+- [[#contributing][Contributing]]
 - [[#gratitude][Gratitude]]
 
 * Installation
@@ -238,6 +239,9 @@ Easy. When on desktop they are simply not Emacs.  Not even Obsidian itself. Emac
 The answer is mostly the same for all of them. Mobile support. Or rather — NO mobile support. I don't buy into the story that "you don't really need your PKM system on mobile", and "serious work is done only on desktop" etc. These are just excuses for the impossibility of building a full-fledged mobile version of Emacs.
 
 So there were two ways to go about it: build a mobile app for something like org-roam (which would be cool, but is above my front-end skills) or build a light-weight Emacs client for something like Obsidian. I chose the simpler task.
+
+* Contributing
+PRs and issues are very welcome. In order to develop locally you need to install [[https://github.com/doublep/eldev/][eldev]]. After that you can run ~make~ commands, in particular ~make test~ and ~make lint~ to make sure that your code will pass all MELPA checks.
 
 * Gratitude
 - The work on Obsidian.el was made considerably easier and definitely more fun thanks to the great work of [[https://github.com/magnars][Magnar Sveen]] and his packages [[https://github.com/magnars/dash.el][dash.el]] and [[https://github.com/magnars/s.el][s.el]]. Thank you for making Elisp almost as convenient as Clojure!

--- a/obsidian.el
+++ b/obsidian.el
@@ -485,9 +485,9 @@ See `markdown-follow-link-at-point' and
 
 (defun obsidian--link-p (s)
   "Check if S matches any of the link regexes."
-  (when s 
-  (or (s-matches-p obsidian--basic-wikilink-regex s)
-      (s-matches-p obsidian--basic-markdown-link-regex s))))
+  (when s
+    (or (s-matches-p obsidian--basic-wikilink-regex s)
+        (s-matches-p obsidian--basic-markdown-link-regex s))))
 
 (defun obsidian--elgrep-get-context (match)
   "Get :context out of MATCH produced by elgrep."
@@ -498,10 +498,10 @@ See `markdown-follow-link-at-point' and
     context))
 
 (defun obsidian--mention-link-p (match)
-  "Check if MATCHES produced by `obsidian--grep' contain a link."
-          (mapcar (lambda (element) 
-                    (when (listp element) 
-                        (obsidian--link-p (obsidian--elgrep-get-context element)))) match))
+  "Check if 'MATCH' produced by `obsidian--grep' is a link."
+  (mapcar (lambda (element)
+            (when (listp element)
+              (obsidian--link-p (obsidian--elgrep-get-context element)))) match))
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."

--- a/obsidian.el
+++ b/obsidian.el
@@ -505,10 +505,11 @@ See `markdown-follow-link-at-point' and
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."
-  (->> (file-name-sans-extension filename)
+  (->> (file-name-sans-extension (file-name-nondirectory filename))
        obsidian--grep
        (-filter #'obsidian--mention-link-p)
-       (-map #'car)))
+       (-map #'car)
+       (-filter (lambda (name) (not (string-equal name filename))))))
 
 (defun obsidian--completing-read-for-matches (coll)
   "Take a COLL of matches produced by elgrep and make a list for completing read."
@@ -520,7 +521,7 @@ See `markdown-follow-link-at-point' and
 (defun obsidian-backlink-jump ()
   "Select a backlink to this file and follow it."
   (interactive)
-  (let* ((backlinks (obsidian--find-links-to-file (file-name-nondirectory (buffer-file-name))))
+  (let* ((backlinks (obsidian--find-links-to-file (obsidian--file-relative-name (buffer-file-name))))
          (dict (obsidian--completing-read-for-matches backlinks))
          (choices (-sort #'string< (-distinct (hash-table-keys dict)))))
     (if choices

--- a/obsidian.el
+++ b/obsidian.el
@@ -485,7 +485,7 @@ See `markdown-follow-link-at-point' and
 
 (defun obsidian--link-p (s)
   "Check if S matches any of the link regexes."
-  (if (not s) nil 
+  (when s 
   (or (s-matches-p obsidian--basic-wikilink-regex s)
       (s-matches-p obsidian--basic-markdown-link-regex s))))
 
@@ -500,7 +500,7 @@ See `markdown-follow-link-at-point' and
 (defun obsidian--mention-link-p (match)
   "Check if MATCHES produced by `obsidian--grep' contain a link."
           (mapcar (lambda (element) 
-                    (if (listp element) 
+                    (when (listp element) 
                         (obsidian--link-p (obsidian--elgrep-get-context element)))) match))
 
 (defun obsidian--find-links-to-file (filename)

--- a/obsidian.el
+++ b/obsidian.el
@@ -498,19 +498,16 @@ See `markdown-follow-link-at-point' and
       context)))
 
 (defun obsidian--mention-link-to-p (filename match)
-  "Check if `MATCH' produced by `obsidian--grep' contain a link."
-;;  (message "FILENAME ---> %s" filename)
-;;  (message "MATCH ---> %s" match)
-
+  "Check if `MATCH' produced by `obsidian--grep' contain a link to `FILENAME'."
   (let* ((result (mapcar (lambda (element)
                            ;; (message "ELEMENT ---> %s" (obsidian--elgrep-get-context element))
                            (if (listp element)
                                (and
                                 (obsidian--link-p (obsidian--elgrep-get-context element))
-                                (string-match-p (format "\\b%s\\b" filename) (format "%s" (obsidian--elgrep-get-context element)))))) (cdr match))))
-;;    (message (format "RESULT ---> %s" result))
-    (when (remove nil result) t)
-))
+                                (string-match-p (format "\\b%s\\b" filename)
+                                                (format "%s" (obsidian--elgrep-get-context element))))))
+                         (cdr match))))
+    (when (remove nil result) t)))
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."

--- a/obsidian.el
+++ b/obsidian.el
@@ -491,9 +491,11 @@ See `markdown-follow-link-at-point' and
 
 (defun obsidian--elgrep-get-context (match)
   "Get :context out of MATCH produced by elgrep."
-  (mapcar 
-   (lambda (element) (plist-get (-flatten element) :context))
-   match))
+  (let* ((result (->> match
+                      (nth 1)
+                      -flatten))
+         (context (plist-get result :context)))
+    context))
 
 (defun obsidian--mention-link-p (match)
   "Check if MATCHES produced by `obsidian--grep' contain a link."

--- a/obsidian.el
+++ b/obsidian.el
@@ -449,15 +449,13 @@ See `markdown-follow-link-at-point' and
 
 (defun obsidian--elgrep-get-context (match)
   "Get :context out of MATCH produced by elgrep."
-  (let* ((result (->> match
-                      (nth 1)
-                      -flatten))
-         (context (plist-get result :context)))
-    context))
+  (mapcar 
+   (lambda (element) (plist-get (-flatten element) :context))
+   match))
 
 (defun obsidian--mention-link-p (match)
-  "Check if MATCH produced by `obsidian--grep' is a link."
-  (obsidian--link-p (obsidian--elgrep-get-context match)))
+  "Check if MATCH produced by `obsidian--grep' contains a link."
+  (obsidian--link-p (format "%s" (obsidian--elgrep-get-context match))))
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."

--- a/obsidian.el
+++ b/obsidian.el
@@ -501,7 +501,7 @@ See `markdown-follow-link-at-point' and
   "Check if MATCHES produced by `obsidian--grep' contain a link."
           (mapcar (lambda (element) 
                     (if (listp element) 
-                        (obsidian--link-p (obsidian--elgrep-get-context element)))nil) match))
+                        (obsidian--link-p (obsidian--elgrep-get-context element)))) match))
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."

--- a/obsidian.el
+++ b/obsidian.el
@@ -497,19 +497,26 @@ See `markdown-follow-link-at-point' and
            (context (plist-get result :context)))
       context)))
 
-(defun obsidian--mention-link-p (match)
+(defun obsidian--mention-link-to-p (filename match)
   "Check if `MATCH' produced by `obsidian--grep' contain a link."
-  (let* ((result (mapcar (lambda (element)
-                           (if (listp element)
-                               (obsidian--link-p (obsidian--elgrep-get-context element)))) (cdr match))))
-    (car (member t result))))
+;;  (message "FILENAME ---> %s" filename)
+;;  (message "MATCH ---> %s" match)
 
+  (let* ((result (mapcar (lambda (element)
+                           ;; (message "ELEMENT ---> %s" (obsidian--elgrep-get-context element))
+                           (if (listp element)
+                               (and
+                                (obsidian--link-p (obsidian--elgrep-get-context element))
+                                (string-match-p (format "\\b%s\\b" filename) (format "%s" (obsidian--elgrep-get-context element)))))) (cdr match))))
+;;    (message (format "RESULT ---> %s" result))
+    (when (remove nil result) t)
+))
 
 (defun obsidian--find-links-to-file (filename)
   "Find any mention of FILENAME in the vault."
   (->> (file-name-sans-extension filename)
        obsidian--grep
-       (-filter #'obsidian--mention-link-p)
+       (-filter (lambda (x) (obsidian--mention-link-to-p (file-name-sans-extension filename) x)))
        (-map #'car)))
 
 (defun obsidian--completing-read-for-matches (coll)


### PR DESCRIPTION
I think I understood what the problem is about backlinks: in your `obsidian--elgrep-get-context` you assume that the elgrep would produce a single `match` each file but you could have multiple match in a single file, so I created this pull request for your repo.

thanks!
D.