### PR TITLE
Add caching to obsidian-list-all-files function

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -430,11 +430,12 @@ Argument S relative file name to clean and convert to absolute."
 
 (defun obsidian-find-file (f)
   "Take file F and either opens directly or offer choice if multiple match."
-  (obsidian-clear-cache)
   (let* ((all-files (->> (obsidian-list-all-files) (-map #'obsidian--file-relative-name)))
          (matches (obsidian--match-files f all-files))
          (file (cl-case (length matches)
-                 (0 f)
+                 (0 (progn
+                      (obsidian-clear-cache)
+                      f))
                  (1 (car matches))
                  (t
                   (let* ((choice (completing-read "Jump to: " matches)))

--- a/obsidian.el
+++ b/obsidian.el
@@ -155,13 +155,23 @@ FILE is an Org-roam file if:
   "Take relative file name F and return expanded name."
   (expand-file-name f obsidian-directory))
 
+(defvar obsidian-files-cache nil "Cache for Obsidian files.")
+
 (defun obsidian-list-all-files ()
   "Lists all Obsidian Notes files that are not in trash.
 
 Obsidian notes files:
 - Pass the `obsidian-file-p' check"
-  (->> (directory-files-recursively obsidian-directory "\.*$")
-       (-filter #'obsidian-file-p)))
+  (unless obsidian-files-cache
+    (setq obsidian-files-cache
+          (->> (directory-files-recursively obsidian-directory "\.*$")
+               (-filter #'obsidian-file-p))))
+  obsidian-files-cache)
+
+(defun obsidian-clear-cache ()
+  "Clears the cache."
+  (interactive)
+  (setq obsidian-files-cache nil))
 
 (defun obsidian-list-all-directories ()
   "Lists all Obsidian sub folders."

--- a/obsidian.el
+++ b/obsidian.el
@@ -386,7 +386,8 @@ In the `obsidian-inbox-directory' if set otherwise in `obsidian-directory' root.
   (let* ((title (read-from-minibuffer "Title: "))
          (filename (s-concat obsidian-directory "/" obsidian-inbox-directory "/" title ".md"))
          (clean-filename (s-replace "//" "/" filename)))
-    (find-file (expand-file-name clean-filename) t)))
+    (find-file (expand-file-name clean-filename) t)
+    (add-hook 'after-save-hook 'obsidian-clear-cache nil t)))
 
 ;;;###autoload
 (defun obsidian-jump ()


### PR DESCRIPTION
This PR adds a caching mechanism to the obsidian-list-all-files function to improve its performance. The function now only scans the Obsidian directory once and subsequently uses the stored result. A new function, obsidian-clear-cache, is introduced to manually clear the cache when necessary.

ref. #39