### PR TITLE
Jayemar/create links with filenames only

### DIFF
--- a/README.org
+++ b/README.org
@@ -168,6 +168,8 @@ Obsidian doesn't insert relative path by default, only does it when there are mu
 ** Inserting links
 [[./resources/insert-link.png]]
 
+When inserting links, two different formats can be used to specify the file: the filename alone, or the path to the file within the Obsidian vault.  The default is to only use the filename, but this behavior can be changed by setting the variable ~obsidian-links-use-vault-path~ to ~t~.  Alternately, using the prefix argument before the call to insert a link will toggle this behavior, inserting a link with the format opposite of this variable.
+
 There are two commands to insert links ~obsidian-insert-link~ and ~obsidian-insert-wikilink~, you can choose one depending on your preferred link format:
 
 *** Inserts a link in Markdown format

--- a/obsidian.el
+++ b/obsidian.el
@@ -360,7 +360,6 @@ Optional argument ARG word to complete."
                    (buffer-substring-no-properties (region-beginning) (region-end))))
          (chosen-file (file-name-nondirectory (completing-read "Link: " all-files)))
          (default-description (file-name-sans-extension chosen-file))
-
          (description (read-from-minibuffer "Description (optional): " (or region default-description))))
     (list :file chosen-file :description description)))
 

--- a/obsidian.el
+++ b/obsidian.el
@@ -354,12 +354,13 @@ Optional argument ARG word to complete."
   (obsidian--update-all-from-front-matter))
 
 (defun obsidian--request-link ()
-  "Service function to request user for link iput."
+  "Service function to request user for link input."
   (let* ((all-files (->> (obsidian-list-all-files) (-map (lambda (f) (file-relative-name f obsidian-directory)))))
          (region (when (use-region-p)
                    (buffer-substring-no-properties (region-beginning) (region-end))))
-         (chosen-file (completing-read "Link: " all-files))
-         (default-description (-> chosen-file file-name-nondirectory file-name-sans-extension))
+         (chosen-file (file-name-nondirectory (completing-read "Link: " all-files)))
+         (default-description (file-name-sans-extension chosen-file))
+
          (description (read-from-minibuffer "Description (optional): " (or region default-description))))
     (list :file chosen-file :description description)))
 

--- a/obsidian.el
+++ b/obsidian.el
@@ -357,6 +357,12 @@ Optional argument ARG word to complete."
   (obsidian-update-tags-list)
   (obsidian--update-all-from-front-matter))
 
+(defun obsidian--format-link (file-path toggle)
+  "Format link based on `obsidian-use-vault-path' and an optional prefix argument"
+  (if obsidian-links-use-vault-path
+      (if toggle (file-name-nondirectory file-path) file-path)
+    (if toggle file-path (file-name-nondirectory file-path))))
+
 (defun obsidian--request-link (&optional toggle-path)
   "Service function to request user for link input.
 
@@ -366,13 +372,9 @@ TOGGLE-PATH is a boolean that will toggle the behavior of
          (region (when (use-region-p)
                    (buffer-substring-no-properties (region-beginning) (region-end))))
          (chosen-file (completing-read "Link: " all-files))
-         (filename-only (file-name-nondirectory chosen-file))
-         (default-description (file-name-sans-extension filename-only))
+         (default-description (-> chosen-file file-name-nondirectory file-name-sans-extension))
          (description (read-from-minibuffer "Description (optional): " (or region default-description)))
-         (file-link (if obsidian-links-use-vault-path
-                        (if toggle-path filename-only chosen-file)
-                      (if toggle-path chosen-file filename-only)))
-         )
+         (file-link (obsidian--format-link chosen-file toggle-path)))
     (list :file file-link :description description)))
 
 ;;;###autoload

--- a/obsidian.el
+++ b/obsidian.el
@@ -67,6 +67,10 @@
   "Subdir to create notes using `obsidian-capture'."
   :type 'directory)
 
+(defcustom obsidian-links-use-vault-path nil
+  "If true, the full vault path for a link will be used instead of just the filename."
+  :type 'boolean)
+
 (eval-when-compile (defvar local-minor-modes))
 
 ;;;###autoload
@@ -353,21 +357,29 @@ Optional argument ARG word to complete."
   (obsidian-update-tags-list)
   (obsidian--update-all-from-front-matter))
 
-(defun obsidian--request-link ()
-  "Service function to request user for link input."
+(defun obsidian--request-link (&optional toggle-path)
+  "Service function to request user for link input.
+
+TOGGLE-PATH is a boolean that will toggle the behavior of
+`obsidian-use-vault-path' for this single link insertion."
   (let* ((all-files (->> (obsidian-list-all-files) (-map (lambda (f) (file-relative-name f obsidian-directory)))))
          (region (when (use-region-p)
                    (buffer-substring-no-properties (region-beginning) (region-end))))
-         (chosen-file (file-name-nondirectory (completing-read "Link: " all-files)))
-         (default-description (file-name-sans-extension chosen-file))
-         (description (read-from-minibuffer "Description (optional): " (or region default-description))))
-    (list :file chosen-file :description description)))
+         (chosen-file (completing-read "Link: " all-files))
+         (filename-only (file-name-nondirectory chosen-file))
+         (default-description (file-name-sans-extension filename-only))
+         (description (read-from-minibuffer "Description (optional): " (or region default-description)))
+         (file-link (if obsidian-links-use-vault-path
+                        (if toggle-path filename-only chosen-file)
+                      (if toggle-path chosen-file filename-only)))
+         )
+    (list :file file-link :description description)))
 
 ;;;###autoload
 (defun obsidian-insert-wikilink ()
   "Insert a link to file in wikiling format."
   (interactive)
-  (let* ((file (obsidian--request-link))
+  (let* ((file (obsidian--request-link current-prefix-arg))
          (filename (plist-get file :file))
          (description (plist-get file :description))
          (no-ext (file-name-sans-extension filename))
@@ -380,7 +392,7 @@ Optional argument ARG word to complete."
 (defun obsidian-insert-link ()
   "Insert a link to file in markdown format."
   (interactive)
-  (let* ((file (obsidian--request-link)))
+  (let* ((file (obsidian--request-link current-prefix-arg)))
     (-> (s-concat "[" (plist-get file :description) "](" (->> (plist-get file :file) (s-replace " " "%20")) ")")
         insert)))
 

--- a/obsidian.el
+++ b/obsidian.el
@@ -376,10 +376,10 @@ TOGGLE-PATH is a boolean that will toggle the behavior of
     (list :file file-link :description description)))
 
 ;;;###autoload
-(defun obsidian-insert-wikilink ()
+(defun obsidian-insert-wikilink (&optional arg)
   "Insert a link to file in wikiling format."
-  (interactive)
-  (let* ((file (obsidian--request-link current-prefix-arg))
+  (interactive "P")
+  (let* ((file (obsidian--request-link arg))
          (filename (plist-get file :file))
          (description (plist-get file :description))
          (no-ext (file-name-sans-extension filename))
@@ -389,10 +389,10 @@ TOGGLE-PATH is a boolean that will toggle the behavior of
     (insert link)))
 
 ;;;###autoload
-(defun obsidian-insert-link ()
+(defun obsidian-insert-link (&optional arg)
   "Insert a link to file in markdown format."
-  (interactive)
-  (let* ((file (obsidian--request-link current-prefix-arg)))
+  (interactive "P")
+  (let* ((file (obsidian--request-link arg)))
     (-> (s-concat "[" (plist-get file :description) "](" (->> (plist-get file :file) (s-replace " " "%20")) ")")
         insert)))
 


### PR DESCRIPTION
Created new variable `obsidian-links-use-vault-path` to specify whether to use filenames only (if value is nil) or the relative path to the file (if value is t).

Also allows for the use of the prefix argument to toggle this behavior if used before the call to insert the link.