### PR TITLE
Call obsidian-reset-cache when calling obsidian-update function

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -350,6 +350,7 @@ Optional argument ARG word to complete."
 (defun obsidian-update ()
   "Command update everything there is to update in obsidian.el (tags, links etc.)."
   (interactive)
+  (obsidian-reset-cache)
   (obsidian-update-tags-list)
   (obsidian--update-all-from-front-matter))
 


### PR DESCRIPTION
Call `obsidian-reset-cache` as part of `obsidian-update` to make sure that the file list is up to date