### PR TITLE
Jayemar/open links in other window

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -467,7 +467,6 @@ Argument S relative file name to clean and convert to absolute."
                  (t
                   (let* ((choice (completing-read "Jump to: " matches)))
                     choice)))))
-    ;; (-> file obsidian--expand-file-name find-file)
     (obsidian--find-file-with-window (obsidian--expand-file-name file) arg)))
 
 (defun obsidian-wiki-link-p ()
@@ -490,7 +489,7 @@ link name must be available via `match-string'."
     (s-concat f ".md")))
 
 (defun obsidian-follow-wiki-link-at-point (&optional arg)
-  "Find Wiki Link at point."
+  "Find Wiki Link at point. Opens wiki links in other window if ARG is non-nil."
   (interactive "P")
   ;; (obsidian-wiki-link-p)
   (thing-at-point-looking-at markdown-regex-wiki-link)
@@ -505,7 +504,8 @@ link name must be available via `match-string'."
           (obsidian-find-file arg)))))
 
 (defun obsidian-follow-markdown-link-at-point (&optional arg)
-  "Find and follow markdown link at point."
+  "Find and follow markdown link at point.
+Opens markdown links in other window if ARG is non-nil.."
   (interactive "P")
   (let ((normalized (s-replace "%20" " " (markdown-link-url))))
     (if (s-contains-p ":" normalized)

--- a/obsidian.el
+++ b/obsidian.el
@@ -518,7 +518,7 @@ Opens markdown links in other window if ARG is non-nil.."
 (defun obsidian-follow-link-at-point (&optional arg)
   "Follow thing at point if possible, such as a reference link or wiki link.
 Opens inline and reference links in a browser.  Opens wiki links
-to other files in the current window, or the another window if
+to other files in the current window, or another window if
 ARG is non-nil.
 See `markdown-follow-link-at-point' and
 `markdown-follow-wiki-link-at-point'."

--- a/obsidian.el
+++ b/obsidian.el
@@ -451,10 +451,6 @@ Argument S relative file name to clean and convert to absolute."
   "Filter ALL-FILES to return list with same name as F."
   (-filter (lambda (el) (s-ends-with-p f el)) all-files))
 
-(defun obsidian--find-file-with-window (file-name &optional arg)
-  "Open file FILE-NAME in same window if ARG is nil, in other window if ARG is set"
-  (if arg (find-file-other-window file-name) (find-file file-name)))
-
 (defun obsidian-find-file (f &optional arg)
   "Take file F and either opens directly or offer choice if multiple match."
   (let* ((all-files (->> (obsidian-list-all-files) (-map #'obsidian--file-relative-name)))
@@ -466,8 +462,9 @@ Argument S relative file name to clean and convert to absolute."
                  (1 (car matches))
                  (t
                   (let* ((choice (completing-read "Jump to: " matches)))
-                    choice)))))
-    (obsidian--find-file-with-window (obsidian--expand-file-name file) arg)))
+                    choice))))
+         (find-fn (if arg #'find-file-other-window #'find-file)))
+    (funcall find-fn (obsidian--expand-file-name file))))
 
 (defun obsidian-wiki-link-p ()
   "Return non-nil if `point' is at a true wiki link.


### PR DESCRIPTION
Allow for opening links in another window as specified by the docstring of `obsidian-follow-link-at-point` and mentioned in issue #55 