### PR TITLE
Jayemar/inserted link replaces highlighted text

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -402,8 +402,8 @@ If text is highlighted, the highlighted text will be replaced by the link."
          (file (s-replace " " "%20" file-raw))
          (description (plist-get file-plist :description))
          (link-str (s-concat "[" description "](" file ")")))
-    ;; (if (use-region-p)
-    ;;     (delete-active-region))
+    (if (use-region-p)
+        (delete-active-region))
     (insert link-str)))
 
 ;;;###autoload

--- a/obsidian.el
+++ b/obsidian.el
@@ -393,11 +393,18 @@ TOGGLE-PATH is a boolean that will toggle the behavior of
 
 ;;;###autoload
 (defun obsidian-insert-link (&optional arg)
-  "Insert a link to file in markdown format."
+  "Insert a link to file in markdown format.
+
+If text is highlighted, the highlighted text will be replaced by the link."
   (interactive "P")
-  (let* ((file (obsidian--request-link arg)))
-    (-> (s-concat "[" (plist-get file :description) "](" (->> (plist-get file :file) (s-replace " " "%20")) ")")
-        insert)))
+  (let* ((file-plist (obsidian--request-link arg))
+         (file-raw (plist-get file-plist :file))
+         (file (s-replace " " "%20" file-raw))
+         (description (plist-get file-plist :description))
+         (link-str (s-concat "[" description "](" file ")")))
+    ;; (if (use-region-p)
+    ;;     (delete-active-region))
+    (insert link-str)))
 
 ;;;###autoload
 (defun obsidian-capture ()


### PR DESCRIPTION
If text is highlighted when inserting a new link, remove highlighted text before inserting new link