### PR TITLE
Add code to optionally use hidden dot files or not based on new variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -130,6 +130,9 @@ When [[https://github.com/abo-abo/hydra][Hydra]] is installed, ~obsidian-hydra~ 
 
 [[./resources/hydra-menu.png]]
 
+** Including hidden dot files
+Obsidian does not track hidden files; obsidian.el can be configured to either track them or ignore them by setting the value of `obsidian-include-hidden-files`.
+
 ** Manual re-scan
 You can update the lists of tags, links etc. manually if it's lagging for some reason by running an interactive command:
 

--- a/tests/test-obsidian.el
+++ b/tests/test-obsidian.el
@@ -4,8 +4,10 @@
 (defvar obsidian--test-dir "./tests/test_vault")
 (defvar obsidian--test--original-dir (or obsidian-directory obsidian--test-dir))
 (defvar obsidian--test--original-tags-list obsidian--tags-list)
-(defvar obsidian--test-number-of-tags 6)
-(defvar obsidian--test-number-of-notes 9)
+(defvar obsidian--test-number-of-tags 9)
+(defvar obsidian--test-number-of-visible-tags 6)
+(defvar obsidian--test-number-of-notes 11)
+(defvar obsidian--test-number-of-visible-notes 9)
 
 (describe "check path setting"
   (before-all (obsidian-specify-path obsidian--test-dir))
@@ -42,6 +44,19 @@
   (it "check file count"
     (expect (length (obsidian-list-all-files)) :to-equal obsidian--test-number-of-notes)))
 
+(describe "obsidian-list-all-visible-files"
+   (before-all (progn
+                 (obsidian-specify-path obsidian--test-dir)
+                 (setq obsidian-include-hidden-files nil)
+                 (obsidian-update)))
+   (after-all (progn
+                (obsidian-specify-path obsidian--test--original-dir)
+                (setq obsidian-include-hidden-files t)
+                (obsidian-update)))
+
+  (it "check file count"
+    (expect (length (obsidian-list-all-files)) :to-equal obsidian--test-number-of-visible-notes)))
+
 (describe "obsidian-find-tags"
   (before-all (obsidian-specify-path obsidian--test-dir))
   (after-all (obsidian-specify-path obsidian--test--original-dir))
@@ -55,6 +70,19 @@
 
   (it "find all tags in the vault"
     (expect (length (obsidian-list-all-tags)) :to-equal obsidian--test-number-of-tags)))
+
+(describe "obsidian-list-visible-tags"
+  (before-all (progn
+                (obsidian-specify-path obsidian--test-dir)
+                (setq obsidian-include-hidden-files nil)
+                (obsidian-update)))
+  (after-all (progn
+               (obsidian-specify-path obsidian--test--original-dir)
+               (setq obsidian-include-hidden-files t)
+               (obsidian-update)))
+
+  (it "find all tags in the vault"
+    (expect (length (obsidian-list-all-tags)) :to-equal obsidian--test-number-of-visible-tags)))
 
 (describe "obsidian-update"
   (before-all (progn

--- a/tests/test_vault/.hidden-file.md
+++ b/tests/test_vault/.hidden-file.md
@@ -1,0 +1,3 @@
+Some text inside of this hidden dot file
+
+#hidden #dot

--- a/tests/test_vault/subdir/.nested-hidden-file.md
+++ b/tests/test_vault/subdir/.nested-hidden-file.md
@@ -1,0 +1,3 @@
+Text inside of a nested hidden dot file
+
+#nesteddot

--- a/tests/test_vault/tilde-file.md~
+++ b/tests/test_vault/tilde-file.md~
@@ -1,0 +1,3 @@
+Words in a file that should be totally ignored because it includes a tilde
+
+#tilde #ignore


### PR DESCRIPTION
Obsidian does not track hidden files (ie "dot" files) by default so I wanted a way for `obsidian.el` to optionally ignore them.  This code branch adds a variable `obsidian-include-hidden-files` that when set to `t` will include them in file lists and when searching for tags, but will ignore these files when set to `nil`.

Additional tests and test files were added to test this functionality.