### PR TITLE
Verify that file exists before attempting to read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "**"
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "**"
 
 jobs:
   test:

--- a/obsidian.el
+++ b/obsidian.el
@@ -36,7 +36,6 @@
 ;; app for syncing and doing more specialized stuff, like viewing notes graphs.
 
 ;;; Code:
-(require 'f)
 (require 'dash)
 (require 's)
 

--- a/obsidian.el
+++ b/obsidian.el
@@ -222,8 +222,7 @@ If you need to run this manually, please report this as an issue on Github."
   "Return string contents of a file or current buffer.
 
 If FILE is not specified, use the current buffer."
-  ;; (if (and file (file-exists-p file))
-  (if file
+  (if (and file (file-exists-p file))
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))
@@ -504,7 +503,7 @@ If the file include directories in its path, we create the file relative to
                      (s-concat obsidian-directory "/"
                                obsidian-inbox-directory "/" f)))
          (cleaned (s-replace "//" "/" filename)))
-    (if (not (file-exists-p cleaned))
+    (if (not (f-exists-p cleaned))
         (progn
           (f-mkdir-full-path (f-dirname cleaned))
           (f-touch cleaned)

--- a/obsidian.el
+++ b/obsidian.el
@@ -215,7 +215,7 @@ If you need to run this manually, please report this as an issue on Github."
   "Return string contents of a file or current buffer.
 
 If FILE is not specified, use the current buffer."
-  (if (and file (f-exists-p file))
+  (if (and file (file-exists-p file))
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))

--- a/obsidian.el
+++ b/obsidian.el
@@ -215,7 +215,8 @@ If you need to run this manually, please report this as an issue on Github."
   "Return string contents of a file or current buffer.
 
 If FILE is not specified, use the current buffer."
-  (if (and file (file-exists-p file))
+  ;; (if (and file (file-exists-p file))
+  (if file
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))

--- a/obsidian.el
+++ b/obsidian.el
@@ -486,7 +486,7 @@ If the file include directories in its path, we create the file relative to
                      (s-concat obsidian-directory "/"
                                obsidian-inbox-directory "/" f)))
          (cleaned (s-replace "//" "/" filename)))
-    (if (not (f-exists-p cleaned))
+    (if (not (file-exists-p cleaned))
         (progn
           (f-mkdir-full-path (f-dirname cleaned))
           (f-touch cleaned)

--- a/obsidian.el
+++ b/obsidian.el
@@ -5,7 +5,7 @@
 ;; Author: Mykhaylo Bilyanskyy
 ;; URL: https://github.com./licht1stein/obsidian.el
 ;; Keywords: obsidian, pkm, convenience
-;; Version: 1.3.3
+;; Version: 1.3.4
 ;; Package-Requires: ((emacs "27.2") (s "1.12.0") (dash "2.13") (markdown-mode "2.5") (elgrep "1.0.0") (yaml "0.5.1"))
 
 ;; This file is NOT part of GNU Emacs.

--- a/obsidian.el
+++ b/obsidian.el
@@ -215,7 +215,7 @@ If you need to run this manually, please report this as an issue on Github."
   "Return string contents of a file or current buffer.
 
 If FILE is not specified, use the current buffer."
-  (if file
+  (if (and file (f-exists-p file))
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))

--- a/obsidian.el
+++ b/obsidian.el
@@ -36,6 +36,7 @@
 ;; app for syncing and doing more specialized stuff, like viewing notes graphs.
 
 ;;; Code:
+(require 'f)
 (require 'dash)
 (require 's)
 


### PR DESCRIPTION
If a file in the vault is unreadable (for example if it has been deleted from the vault) then this function will throw an exception.  This causes the `obisidan-tag-find` function to fail on this missing file.

The change made in this merge request will first check that a file exists before attempting to read it.  Unavailable files will be skipped.