### PR TITLE
fixed issue #64

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -478,8 +478,7 @@ Argument S relative file name to clean and convert to absolute."
 
 (defun obsidian--match-files (f all-files)
   "Filter ALL-FILES to return list with same name as F."
-  (-filter (lambda (el) (s-ends-with-p f el)) all-files))
-
+  (-filter (lambda (el) (s-equals-p f (obsidian--file-relative-name el))) all-files))
 
 (defun obsidian--prepare-new-file-from-rel-path (p)
   "Create file if it doesn't exist and return full system path for relative path P.


### PR DESCRIPTION
obsidian-follow-link-at-point shouldn't offer a multiple selections of files with the same suffix searched