### PR TITLE
Add support of wiki links with section, like [[filename#section]]

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -545,7 +545,12 @@ link name must be available via `match-string'."
   "Add extension to wiki link F if none."
   (if (file-name-extension f)
       f
-    (s-concat f ".md")))
+    (s-concat (obsidian--remove-section f) ".md")))
+
+(defsubst obsidian--remove-section (s)
+  "Remove section from file path.
+   From 'filename#section' keep only the 'filename'."
+   (replace-regexp-in-string "#.*$" "" s))
 
 (defun obsidian-follow-wiki-link-at-point (&optional arg)
   "Find Wiki Link at point. Opens wiki links in other window if ARG is non-nil."


### PR DESCRIPTION
In Obsidian the [[filename#section]] form is supported, so add it here, too. Removing the section part is the best in `obsidian-wiki->normal` as this is the place where the `.md` extension is added to the link.

Fixes Issue #70.