### PR TITLE
obsidian--match-files finds all files with given basename & more

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -492,7 +492,7 @@ Argument S relative file name to clean and convert to absolute."
 
 (defun obsidian--match-files (f all-files)
   "Filter ALL-FILES to return list with same name as F."
-  (-filter (lambda (el) (s-equals-p f (obsidian--file-relative-name el))) all-files))
+  (-filter (lambda (el) (or (s-equals-p f el) (s-ends-with-p (concat "/" f) el))) all-files))
 
 (defun obsidian--prepare-new-file-from-rel-path (p)
   "Create file if it doesn't exist and return full system path for relative path P.


### PR DESCRIPTION
When issue #64 was opened, obsidian--match-files was lazy, only the suffix was checked, so it found for 'aa.md' both 'aa.md' and 'baa.md'. Its solution broke the relative file name usage (e.g. [[aa.md]] was "found" in the inbox).

To cover both use case the match needs to be either exact (relative to the vault root), or partial, where the searched file name prefixed with '/' is searched with s-ends-with-p.

Fixes issue #72.