### PR TITLE
Jayemar/check file exists before reading

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -222,7 +222,8 @@ If you need to run this manually, please report this as an issue on Github."
   "Return string contents of a file or current buffer.
 
 If FILE is not specified, use the current buffer."
-  (if file
+  (if (and file (file-exists-p file))
+      ;; TODO: Will this work as intended if using a buffer?
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))

--- a/obsidian.el
+++ b/obsidian.el
@@ -231,7 +231,6 @@ If you need to run this manually, please report this as an issue on Github."
 
 If FILE is not specified, use the current buffer."
   (if (and file (file-exists-p file))
-      ;; TODO: Will this work as intended if using a buffer?
       (with-temp-buffer
         (insert-file-contents file)
         (buffer-substring-no-properties (point-min) (point-max)))


### PR DESCRIPTION
Check that a file exists before attempting to read it.  This prevents an error being thrown if a file doesn't exist which can happen if it has been removed by an external program, for example.