### PR TITLE
Allow searching for tags within front matter

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -249,8 +249,11 @@ If FILE is not specified, use the current buffer."
 (defun obsidian-find-tags (s)
   "Find all #tags in string.
 Argument S string to find tags in."
-  (->> (s-match-strings-all obsidian--tag-regex s)
-       -flatten))
+  (let ((front-matter (obsidian-find-yaml-front-matter s))
+        (add-tag (lambda (tag) (concat "#" tag))))
+    (->> (s-match-strings-all obsidian--tag-regex s)
+         (append (and front-matter (mapcar add-tag (gethash 'tags front-matter))))
+         -flatten)))
 
 (defun obsidian-get-yaml-front-matter ()
   "Return the text of the YAML front matter of the current buffer.


### PR DESCRIPTION
Previously, the command `obsidian-tag-find` and related would not return any tags that were located in the front matter of a file, only the tags present in the body. Now, all tags present in your obsidian vault are correctly found.