### PR TITLE
Fix doc string

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -234,7 +234,7 @@ Obsidian notes files:
   obsidian-files-cache)
 
 (defun obsidian-clear-cache ()
-  "Clears the obsidiean.el cache.
+  "Clears the obsidian.el cache.
 
 If you need to run this manually, please report this as an issue on Github."
   (interactive)


### PR DESCRIPTION
This PR fixes the docstring for `obsidian-clear-cache`.

```diff
- "Clears the obsidiean.el cache.
+ "Clears the obsidian.el cache.
```