### PR TITLE
Verify that the aliases of the files the test vault are handled correctly

### DIFF
--- a/tests/test-obsidian.el
+++ b/tests/test-obsidian.el
@@ -125,7 +125,17 @@ key4:
 
   (it "check that front-matter is ignored if not at the top of file"
     (expect (obsidian-find-yaml-front-matter obsidian--test-incorret-front-matter--not-start-of-file)
-	    :to-equal nil)))
+	    :to-equal nil))
+
+  (it "check that front-matter in vault is retrieved correctly"
+    (let ((alias-list (obsidian--all-aliases)))
+      (expect (-count #'identity alias-list) :to-equal 6)
+      (expect (seq-contains-p alias-list "2") :to-equal t)
+      (expect (seq-contains-p alias-list "2-sub-alias") :to-equal t)
+      (expect (seq-contains-p alias-list "complex file name") :to-equal t)
+      (expect (seq-contains-p alias-list "alias-one-off") :to-equal t)
+      (expect (seq-contains-p alias-list "alias1") :to-equal t)
+      (expect (seq-contains-p alias-list "alias2") :to-equal t))))
 
 (describe "obsidian--link-p"
   (it "non link"


### PR DESCRIPTION
While experimenting with the alias retrieval code, I noticed that we weren't actually testing the aliases of the files in the test vault.  This PR is a basic check that we're retrieval all of the aliases that we expect and no more.